### PR TITLE
More display improvements, fixed bug with ambiguous \circ operator.

### DIFF
--- a/src/SpaceGroups.jl
+++ b/src/SpaceGroups.jl
@@ -2,8 +2,9 @@ module SpaceGroups
 
 import StaticArrays: SMatrix, SVector
 import LinearAlgebra: ⋅, I
+import Base: *, ∘
 
-export SpaceGroupQuotient, SpaceGroupElement, @SGE
+export SpaceGroupQuotient, SpaceGroupElement, @SGE, ∘
 export WyckoffPosition
 export AffinePhase, ComplexOrbit, RealOrbit, ExtinctOrbit, FormalOrbit, PhysicalOrbit
 export make_orbit

--- a/src/orbit.jl
+++ b/src/orbit.jl
@@ -30,6 +30,14 @@ AffinePhase(k::SVector{N,T}, ϕ::Rational{T}) where {N,T<:Integer} =
     AffinePhase{N,T}(k, ϕ)
 
 
+function Base.show(io::IO, ::MIME"text/plain", x::AffinePhase)
+    print(io, "AffinePhase(k = $(x.k), ϕ = $(x.ϕ))")
+end
+
+function Base.show(io::IO, x::AffinePhase)
+    print(io, "AP($(x.k), $(x.ϕ))")
+end
+
 """
     *(g::SpaceGroupElement, ap::AffinePhase{N,T}) where {N,T<:Integer}
 
@@ -102,4 +110,28 @@ function make_orbit(k::SVector{N,T}, G::SpaceGroupQuotient{N,T})::FormalOrbit{N,
         # the phase of each partial wave is already known up to a global phase:
         return ComplexOrbit([AffinePhase(k, d[k]) for k in keys(d)])
     end
+end
+
+function Base.show(io::IO, ::MIME"text/plain", x::ComplexOrbit)
+    print(io, "ComplexOrbit with $(length(x.aps)) elements")
+end
+
+function Base.show(io::IO, x::ComplexOrbit)
+    print(io, "ComplexOrbit with $(length(x.aps)) elements")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", x::RealOrbit)
+    print(io, "RealOrbit with $(length(x.aps)) elements")
+end
+
+function Base.show(io::IO, x::RealOrbit)
+    print(io, "RealOrbit with $(length(x.aps)) elements")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", x::ExtinctOrbit)
+    print(io, "ExtinctOrbit with $(length(x.k)) elements")
+end
+
+function Base.show(io::IO, x::ExtinctOrbit)
+    print(io, "ExtinctOrbit with $(length(x.k)) elements")
 end

--- a/src/spacegroup.jl
+++ b/src/spacegroup.jl
@@ -27,28 +27,28 @@ The group action is given by the formula x ↦ a*x+b.
 ```julia
 julia> using StaticArrays
 
-julia> e1 = SpaceGroupElement{2,Int}(SMatrix{2,2,Int}([1 0; 0 1]))
-SpaceGroupElement{2,Int64}(
-  [1 0; 0 1],
-  [0, 0]
+julia> e1 = SpaceGroupElement(SMatrix{2,2,Int}([0 1; -1 0]))
+SpaceGroupElement(
+  a = [0 1; -1 0],
+  b = [0//1, 0//1]
 )
 
-julia> e2 = SpaceGroupElement{2,Int}(SVector{2,Int}([1, 1]))
-SpaceGroupElement{2,Int64}(
-  [1 0; 0 1],
-  [1, 1]
+julia> e2 = SpaceGroupElement(SVector{2,Int}([1, 1]))
+SpaceGroupElement(
+  a = [1 0; 0 1],
+  b = [1//1, 1//1]
 )
 
 julia> e1*e2
-SpaceGroupElement{2,Int64}(
-  [1 0; 0 1],
-  [1, 1]
+SpaceGroupElement(
+  a = [0 1; -1 0],
+  b = [1//1, -1//1]
 )
 
 julia> e1∘e2
-SpaceGroupElement{2,Int64}(
-  [1 0; 0 1],
-  [0, 0]
+SpaceGroupElement(
+  a = [0 1; -1 0],
+  b = [0//1, 0//1]
 )
 """
 struct SpaceGroupElement{N,T<:Integer} <: GroupElement
@@ -174,15 +174,24 @@ end
     # Example
     ```julia
     julia> @SGE([1 0; 0 -1], [1//3, 2//3])
-    SpaceGroupElement{2, Int64}([1 0; 0 -1], Rational{Int64}[1//3, 2//3])
+    SpaceGroupElement(
+      a = [1 0; 0 -1],
+      b = [1//3, 2//3]
+    )
     ```
     ```julia
     julia> @SGE([1 0; 0 -1])
-    SpaceGroupElement{2, Int64}([1 0; 0 -1], Rational{Int64}[0, 0])
+    SpaceGroupElement(
+      a = [1 0; 0 -1],
+      b = [0//1, 0//1]
+    )
     ```
     ```julia
     julia> @SGE([1//3, 2//3])
-    SpaceGroupElement{2, Int64}([1 0; 0 1], Rational{Int64}[1//3, 2//3])
+    SpaceGroupElement(
+      a = [1 0; 0 1],
+      b = [1//3, 2//3]
+    )
     ```
 """
 macro SGE(args...)


### PR DESCRIPTION
Added shortened versions of `Base.show()` for all three types of orbits. The corresponding docstrings are updated, fixed a bug with ambiguous operator \circ.