### PR TITLE
Fixing bugs in constructor dispatch and stabilizer_quotient function

### DIFF
--- a/src/SpaceGroups.jl
+++ b/src/SpaceGroups.jl
@@ -1,11 +1,11 @@
 module SpaceGroups
 
 import StaticArrays: SMatrix, SVector
-import LinearAlgebra: ⋅, I
+import LinearAlgebra: ⋅, I, rank
 import Base: *, ∘
 
 export SpaceGroupQuotient, SpaceGroupElement, @SGE, ∘
-export WyckoffPosition
+export WyckoffPosition, stabilizer_quotient, is_valid_wyckoff, normalize
 export AffinePhase, ComplexOrbit, RealOrbit, ExtinctOrbit, FormalOrbit, PhysicalOrbit
 export make_orbit
 


### PR DESCRIPTION
Fixed type error and unnecessary type specialization in constructors of `WyckoffPosition`. 

The function `stabilizer_quotient` also contained a bug, precluding a proper comparison of normalized Wyckoff positions.  Fixed in 80f53d0 .