### PR TITLE
Feature/refactor finite groups

### DIFF
--- a/src/finitegroup.jl
+++ b/src/finitegroup.jl
@@ -7,49 +7,8 @@ An abstract type representing an element of a group.
 """
 abstract type GroupElement end
 
-
-"""
-    FiniteGroup{E <: GroupElement}
-
-Represents a finite group with elements of type `E`.
-
-# Type Parameters
-- `E <: GroupElement`: The type of the elements in the group, which must be a subtype of `GroupElement` and provide a composition operation `∘`.
-
-# Fields
-- `e::Set{E}`: The set of all group elements.
-
-# Example
-```julia
-struct MyElement <: GroupElement
-    # Define the structure of your group element here
-end
-
-function ∘(x::MyElement, y::MyElement)
-    # Define the group operation here
-end
-
-# Define the generators of the group
-gen = (MyElement(),)  # An iterable of group elements
-group = FiniteGroup{MyElement}(gen)
-```
-"""
-struct FiniteGroup{E <: GroupElement}
-    e::Set{E}
-
-    function (::Type{<:FiniteGroup})(gen)
-        new{Base.eltype(gen)}(generate_(gen))
-    end
-end
-
-"""
-    FiniteGroup{E <: GroupElement}() where {E <: GroupElement}
-    Default constructor creates the trivial finite group with only the identity element.
-"""
-FiniteGroup{E}() where {E <: GroupElement} = FiniteGroup{E}(Set{E}())
-
-function generate_(gen)
-    identity=eltype(gen)()
+function generate_(gen::AbstractVector{E})::Set{E} where E<:GroupElement
+    identity=E()
     e = Set((identity,)) 
     last = e
     while true
@@ -61,10 +20,37 @@ function generate_(gen)
     e
 end
 
+
+struct FiniteGroup{E <: GroupElement}
+    d::Dict{E, Int}
+
+    function (::Type{<:FiniteGroup})(gen::AbstractVector{E}) where E <: GroupElement
+        e=generate_(gen)
+        identity=E()
+        # By convention, the index of the neutral element is 1
+        d=Dict{E, Int}(identity=>1) 
+        i=1
+        for k in e
+            if k!=identity
+                i+=1
+                d[k]=i
+            end
+        end
+        new{E}(d)
+    end
+end
+
+"""
+    FiniteGroup{E <: GroupElement}() where {E <: GroupElement}
+    Default constructor creates the trivial finite group with only the identity element.
+"""
+FiniteGroup{E}() where {E <: GroupElement} = FiniteGroup{E}(E[])
+
+
 # Iteration
-iterate(fg::FiniteGroup) = iterate(fg.e)
-iterate(fg::FiniteGroup, i) = iterate(fg.e, i)
+iterate(fg::FiniteGroup) = iterate(keys(fg.d))
+iterate(fg::FiniteGroup, i) = iterate(keys(fg.d), i)
 
 # Length and element type
-eltype(fg::FiniteGroup) = eltype(fg.e)
-length(fg::FiniteGroup) = length(fg.e)
+eltype(fg::FiniteGroup) = eltype(keys(fg.d))
+length(fg::FiniteGroup) = length(fg.d)

--- a/src/finitegroup.jl
+++ b/src/finitegroup.jl
@@ -8,9 +8,9 @@ An abstract type representing an element of a group.
 abstract type GroupElement end
 
 # Fallback methods to enforce interface implementation
-identity(::Type{E}) where E <: GroupElement = error("Define identity(::Type{$E})")
+identity(::Type{E}) where E<:GroupElement = error("Define identity(::Type{$E})")
 
-function ∘(a::E, b::E) where E <: GroupElement
+function ∘(a::E, b::E) where E<:GroupElement
     msg = """
     The group operation '∘' not implemented for group elements of type `$E`.
     To use this type with the FiniteGroup structure, define the method:
@@ -20,28 +20,37 @@ function ∘(a::E, b::E) where E <: GroupElement
 end
 
 function generate_(gen::AbstractVector{E})::Set{E} where E<:GroupElement
-    s = Set((identity(E),)) 
+    s = Set((identity(E),))
     last = s
     while true
         found = setdiff((x ∘ y for x in gen, y in last), s)
-        if isempty(found) break end
+        if isempty(found)
+            break
+        end
         union!(s, found)
         last = found
     end
     s
 end
 
+
 struct OperationCache
     tabmul::Matrix{Int}
     tabinv::Vector{Int}
 end
 
-mutable struct FiniteGroupCache{E}
-    oc::Union{Nothing, OperationCache}
-    # etc.
-
-    FiniteGroupCache{E}() where {E} = new{E}(nothing)
+struct ConjugacyCache
+    conjind::Vector{Int}
+    conjcomp::Vector{Vector{Int}}
 end
+
+mutable struct FiniteGroupCache
+    oc::Union{Nothing,OperationCache}
+    cc::Union{Nothing, ConjugacyCache}
+
+    FiniteGroupCache() = new(nothing, nothing)
+end
+
 
 """
     FiniteGroup{E <: GroupElement}
@@ -80,21 +89,21 @@ gen = [MyElement()]  # An `AbstractVector{MyElement}`
 group = FiniteGroup{MyElement}(gen)
 ```
 """
-struct FiniteGroup{E <: GroupElement}
-    d::Dict{E, Int}
+struct FiniteGroup{E<:GroupElement}
+    d::Dict{E,Int}
     e::Vector{E}
-    _cache::FiniteGroupCache{E}
+    _cache::FiniteGroupCache
     _lock::ReentrantLock
 
-    function (::Type{<:FiniteGroup})(gen::AbstractVector{E}) where E <: GroupElement
-        s=generate_(gen)
-        id=identity(E)
-        e=Vector{E}(undef, length(s))        
-        e[1]=id # By convention, the index of the neutral element is 1
-        e[2:end].=(g for g in s if g != id)
-        d=Dict{E, Int}(g=>i for (i,g) in enumerate(e)) 
-        i=1
-        new{E}(d, e, FiniteGroupCache{E}(), ReentrantLock())
+    function (::Type{<:FiniteGroup})(gen::AbstractVector{E}) where E<:GroupElement
+        s = generate_(gen)
+        id = identity(E)
+        e = Vector{E}(undef, length(s))
+        e[1] = id # By convention, the index of the neutral element is 1
+        e[2:end] .= (g for g in s if g != id)
+        d = Dict{E,Int}(g => i for (i, g) in enumerate(e))
+        i = 1
+        new{E}(d, e, FiniteGroupCache(), ReentrantLock())
     end
 end
 
@@ -102,25 +111,13 @@ end
     FiniteGroup{E <: GroupElement}() where {E <: GroupElement}
     Default constructor creates the trivial finite group with only the identity element.
 """
-FiniteGroup{E}() where {E <: GroupElement} = FiniteGroup{E}(E[])
+FiniteGroup{E}() where {E<:GroupElement} = FiniteGroup{E}(E[])
 
-function OperationCache(G::FiniteGroup)
-    n=length(G.e)
-    tabmul=Matrix{Int}(undef, n, n)
-    tabinv=Vector{Int}(undef, n)
-    for i in 1:n
-        for j in 1:n
-            k=G.d[G.e[i] ∘ G.e[j]]
-            tabmul[i,j]=k
-            if k==1
-                tabinv[i]=j
-            end
-        end
-    end
-    OperationCache(tabmul, tabinv)
-end
 
-function _ensure_cache(G::FiniteGroup{E}, field::Symbol, fieldtype::DataType) where E<:GroupElement
+
+
+
+function _ensure_cache(G::FiniteGroup, field::Symbol, fieldtype::DataType)
     isnothing(getfield(G._cache, field)) || return nothing
     lock(G._lock) do
         isnothing(getfield(G._cache, field)) || return nothing
@@ -129,16 +126,82 @@ function _ensure_cache(G::FiniteGroup{E}, field::Symbol, fieldtype::DataType) wh
     nothing
 end
 
-@inline (_inv(g::E, G::FiniteGroup{E})::E) where E<:GroupElement = G.e[G._cache.oc.tabinv[G.d[g]]]
 
-function inv(g::E, G::FiniteGroup{E})::E where E<:GroupElement
-    _ensure_cache(G, :oc, OperationCache)
-    G.e[G._cache.oc.tabinv[G.d[g]]]
+
+function OperationCache(G::FiniteGroup)
+    n = length(G.e)
+    tabmul = Matrix{Int}(undef, n, n)
+    tabinv = Vector{Int}(undef, n)
+    for i in 1:n
+        for j in 1:n
+            k = G.d[G.e[i]∘G.e[j]]
+            tabmul[i, j] = k
+            if k == 1
+                tabinv[i] = j
+            end
+        end
+    end
+    OperationCache(tabmul, tabinv)
 end
 
-function _tabmul(G::FiniteGroup{E})::Matrix{Int} where E<:GroupElement
+
+
+function _tabmul(G::FiniteGroup)::Matrix{Int}
     _ensure_cache(G, :oc, OperationCache)
     G._cache.oc.tabmul
+end
+
+function _tabinv(G::FiniteGroup)::Vector{Int}
+    _ensure_cache(G, :oc, OperationCache)
+    G._cache.oc.tabinv
+end
+
+function inv(g::E, G::FiniteGroup{E})::E where E<:GroupElement
+    tabinv = _tabinv(G)
+    G.e[tabinv[G.d[g]]]
+end
+
+
+
+function ConjugacyCache(G::FiniteGroup)
+    tabmul = _tabmul(G)
+    tabinv = _tabinv(G)
+    conjind = zeros(Int, length(G))
+    nc = 0
+    for i in eachindex(conjind)
+        if conjind[i] != 0
+            continue
+        end
+        nc += 1 # New class found
+        conjind[i] = nc
+        for j in eachindex(G.e)
+            jinv = tabinv[j]
+            k = tabmul[jinv, tabmul[i, j]]
+            conjind[k] = nc
+        end
+    end
+    conjcomp = [Int[] for n in 1:nc]
+    for i in eachindex(conjind)
+        push!(conjcomp[conjind[i]], i)
+    end
+    ConjugacyCache(conjind, conjcomp)
+end
+
+function _conjind(G::FiniteGroup)::Vector{Int}
+    _ensure_cache(G, :cc, ConjugacyCache)
+    G._cache.cc.conjind
+end
+
+function _conjcomp(G::FiniteGroup)::Vector{Vector{Int}}
+    _ensure_cache(G, :cc, ConjugacyCache)
+    G._cache.cc.conjcomp
+end
+
+function conjugacy_class(g::E, G::FiniteGroup{E})::Vector{E} where E<:GroupElement
+    conjind=_conjind(G)
+    conjcomp=_conjcomp(G)
+    ind=conjind[G.d[g]] # Class index
+    [G.e[i] for i in conjcomp[ind]]
 end
 
 # Iteration

--- a/src/finitegroup.jl
+++ b/src/finitegroup.jl
@@ -7,36 +7,94 @@ An abstract type representing an element of a group.
 """
 abstract type GroupElement end
 
-function generate_(gen::AbstractVector{E})::Set{E} where E<:GroupElement
-    identity=E()
-    e = Set((identity,)) 
-    last = e
-    while true
-        found = setdiff((x ∘ y for x in gen, y in last), e)
-        if isempty(found) break end
-        union!(e, found)
-        last = found
-    end
-    e
+# Fallback methods to enforce interface implementation
+identity(::Type{E}) where E <: GroupElement = error("Define identity(::Type{$E})")
+
+function ∘(a::E, b::E) where E <: GroupElement
+    msg = """
+    The group operation '∘' not implemented for group elements of type `$E`.
+    To use this type with the FiniteGroup structure, define the method:
+    `∘(a::$E, b::$E) = ...`
+    """
+    error(msg)
 end
 
+function generate_(gen::AbstractVector{E})::Set{E} where E<:GroupElement
+    s = Set((identity(E),)) 
+    last = s
+    while true
+        found = setdiff((x ∘ y for x in gen, y in last), s)
+        if isempty(found) break end
+        union!(s, found)
+        last = found
+    end
+    s
+end
 
+struct OperationCache
+    tabmul::Matrix{Int}
+    tabinv::Vector{Int}
+end
+
+mutable struct FiniteGroupCache{E}
+    oc::Union{Nothing, OperationCache}
+    # etc.
+
+    FiniteGroupCache{E}() where {E} = new{E}(nothing)
+end
+
+"""
+    FiniteGroup{E <: GroupElement}
+
+Represents a finite group with elements of type `E`.
+
+# Type Parameters
+- `E <: GroupElement`: The type of the elements in the group, which must be a 
+  subtype of `GroupElement` and provide the group operation `∘`, which must be associative, as well as the 
+  function `identity(::Type{E})` returning the neutral element of the group. 
+  The type `E` should be preferrably immutable, as it will be the type of keys 
+  in a dictionary. The equality of objects of type `E` should be equivalent to 
+  equality of the corresponding group elements. 
+
+# Fields
+- `d::Dict{E, Int}`: The keys of `d` are group elements and the values are 
+  arbitrarily assigned indices (with the convention that the neutral element
+  corresponds to the index 1). Reciprocal to `e`: `d[e[i]]=i`
+- `e::Vector{E}`: The vector of group elements. Reciprocal to `d`: `e[d[g]]=g` 
+- `_cache::FiniteGroupCache{E}`: This structure holds all data derived from `d`,
+  and lazily inititialized when the corresponding functionality is requested
+- `_lock::ReentrantLock`: Lock for thread-safe lazy initialization
+
+# Example
+```julia
+struct MyElement <: GroupElement
+    # Define the structure of your group element here
+end
+
+function ∘(x::MyElement, y::MyElement)
+    # Define the group operation here
+end
+
+# Define the generators of the group
+gen = [MyElement()]  # An `AbstractVector{MyElement}`
+group = FiniteGroup{MyElement}(gen)
+```
+"""
 struct FiniteGroup{E <: GroupElement}
     d::Dict{E, Int}
+    e::Vector{E}
+    _cache::FiniteGroupCache{E}
+    _lock::ReentrantLock
 
     function (::Type{<:FiniteGroup})(gen::AbstractVector{E}) where E <: GroupElement
-        e=generate_(gen)
-        identity=E()
-        # By convention, the index of the neutral element is 1
-        d=Dict{E, Int}(identity=>1) 
+        s=generate_(gen)
+        id=identity(E)
+        e=Vector{E}(undef, length(s))        
+        e[1]=id # By convention, the index of the neutral element is 1
+        e[2:end].=(g for g in s if g != id)
+        d=Dict{E, Int}(g=>i for (i,g) in enumerate(e)) 
         i=1
-        for k in e
-            if k!=identity
-                i+=1
-                d[k]=i
-            end
-        end
-        new{E}(d)
+        new{E}(d, e, FiniteGroupCache{E}(), ReentrantLock())
     end
 end
 
@@ -46,6 +104,33 @@ end
 """
 FiniteGroup{E}() where {E <: GroupElement} = FiniteGroup{E}(E[])
 
+function OperationCache(G::FiniteGroup)
+    n=length(G.e)
+    tabmul=Matrix{Int}(undef, n, n)
+    tabinv=Vector{Int}(undef, n)
+    for i in 1:n
+        for j in 1:n
+            k=G.d[G.e[i] ∘ G.e[j]]
+            tabmul[i,j]=k
+            if k==1
+                tabinv[i]=j
+            end
+        end
+    end
+    OperationCache(tabmul, tabinv)
+end
+
+@inline _inv(g::E, G::FiniteGroup{E}) where E<:GroupElement = G.e[G._cache.oc.tabinv[G.d[g]]]
+
+function inv(g::E, G::FiniteGroup{E})::E where E<:GroupElement
+    isnothing(G._cache.oc) || return _inv(g, G)
+    lock(G._lock) do 
+        isnothing(G._cache.oc) || return _inv(g, G)
+        G._cache.oc = OperationCache(G)
+        return _inv(g, G)
+    end
+
+end
 
 # Iteration
 iterate(fg::FiniteGroup) = iterate(keys(fg.d))

--- a/src/spacegroup.jl
+++ b/src/spacegroup.jl
@@ -347,6 +347,6 @@ SpaceGroupQuotient (dimension 2, order 4)
 const SpaceGroupQuotient{N,T} = FiniteGroup{SpaceGroupElement{N,T}}
 
 function Base.show(io::IO, ::MIME"text/plain", G::SpaceGroupQuotient{N,T}) where {N,T}
-    print(io, "SpaceGroupQuotient (dimension $N, order $(length(G.e)))")
+    print(io, "SpaceGroupQuotient (dimension $N, order $(length(G)))")
 end
 

--- a/src/spacegroup.jl
+++ b/src/spacegroup.jl
@@ -60,9 +60,11 @@ Brings the translation vector of a space group element inside the standard unit 
 # Returns
 - A new `SpaceGroupElement` with the same linear transformation matrix and a reduced translation vector.
 """
-function reduce(g::SpaceGroupElement{N,T}) where{N, T<:Integer}
+reduce(g::SpaceGroupElement{N,T}) where{N, T<:Integer} =
     return SpaceGroupElement{N,T}(g.a, g.b-floor.(g.b))
-end
+
+identity(::Type{SpaceGroupElement{N,T}}) where{N, T<:Integer} = 
+    SpaceGroupElement(one(SMatrix{N,N,T}), zeros(SVector{N, Rational{T}}))
 
 """
     SpaceGroupElement{N,T}()


### PR DESCRIPTION
The cache of the multiplication table and conjugacy classes is added to the finite groups (with the lazy initialization).